### PR TITLE
Updated test suite adapters for CLERIC, cl-erlang-term, and cl-epmd

### DIFF
--- a/testsuites/testsuites.lisp
+++ b/testsuites/testsuites.lisp
@@ -981,13 +981,11 @@ just passed to the QUICKLISP:QUICKLOAD."
 
 (defmethod libtest ((library-name (eql :cleric)))
   ;; The test framework used: fiveam.
-  (quicklisp:quickload :cleric)
   (quicklisp:quickload :cleric-test)
   (run-fiveam-test-suite (read-from-string "cleric-test:all-tests")))
 
 (defmethod libtest ((library-name (eql :cl-erlang-term)))
   ;; The test framework used: fiveam.
-  (quicklisp:quickload :erlang-term)
   (quicklisp:quickload :erlang-term-test)
   (run-fiveam-test-suite (read-from-string "erlang-term-test:all-tests")))
 


### PR DESCRIPTION
The test suite adapters for CLERIC, cl-erlang-term, and cl-epmd are now using the new 'all-tests' suite in these projects so that cl-test-grid doesn't have to be updated every time a new test suite is added.

I also cleaned up a little. erlang-term-test is now recognized by Quicklisp, so we don't have to add it manually to the ASDF registry anymore.
