### PR TITLE
Initial Port to clasp

### DIFF
--- a/agent/complete-test-run.lisp
+++ b/agent/complete-test-run.lisp
@@ -149,13 +149,13 @@ data (libraries test suites output and the run results) will be saved."
   (merge-pathnames (lib-log-name lib-name)
                    (test-run-log-dir test-run-directory)))
 
-(defparameter +libtest-timeout-seconds+ #.(* 15 60)
+(defparameter +libtest-timeout-seconds+ #-clasp  #.(* 15 60) #+clasp #.(* 15 60 4)
   "Maximum number of seconds we give each library test suite
 to complete. After this time we consider the test suite
 as hung, kill the lisp process and record :TIMEOUT
 as the library test result.")
 
-(defparameter +loadtest-timeout-seconds+ #.(* 15 60)
+(defparameter +loadtest-timeout-seconds+ #-clasp #.(* 15 60) #+clasp #.(* 15 60 4)
   "Maximum number of seconds we give each ASDF system to load
 in a fresh lisp process.  After this time we consider system
 as hung, kill the lisp process and record :TIMEOUT

--- a/agent/complete-test-run.lisp
+++ b/agent/complete-test-run.lisp
@@ -149,13 +149,13 @@ data (libraries test suites output and the run results) will be saved."
   (merge-pathnames (lib-log-name lib-name)
                    (test-run-log-dir test-run-directory)))
 
-(defparameter +libtest-timeout-seconds+ #-clasp  #.(* 15 60) #+clasp #.(* 15 60 4)
+(defparameter +libtest-timeout-seconds+ #.(* 15 60)
   "Maximum number of seconds we give each library test suite
 to complete. After this time we consider the test suite
 as hung, kill the lisp process and record :TIMEOUT
 as the library test result.")
 
-(defparameter +loadtest-timeout-seconds+ #-clasp #.(* 15 60) #+clasp #.(* 15 60 4)
+(defparameter +loadtest-timeout-seconds+ #.(* 15 60)
   "Maximum number of seconds we give each ASDF system to load
 in a fresh lisp process.  After this time we consider system
 as hung, kill the lisp process and record :TIMEOUT

--- a/agent/lisp-exe.lisp
+++ b/agent/lisp-exe.lisp
@@ -30,6 +30,7 @@
            #:ecl
            #:compiler ; ecl slot accessor
            #:lispworks
+           #:clasp
 
            ;; the main function of interest for test-grid agent
            #:run-with-timeout
@@ -122,6 +123,8 @@ Otherwise he may just ignore the condition."))
              :accessor compiler
              :initarg :compiler
              :initform (error "compiler must be either :bytecode or :lisp-to-c. Can not be NIL"))))
+
+(defclass clasp (single-exe-lisp-exe) ())
 
 (defclass acl (single-exe-lisp-exe) ())
 ;; Lispwork was not verified, as I don't have a license,
@@ -250,6 +253,13 @@ command, the rest strings are the command arguments."))
           "--no-userinit"
           ,@(prepend-each "--eval" form-strings)
           "--eval" "(sb-ext:quit)")))
+
+(defmethod make-command-line ((lisp-exe clasp) form-strings)
+  (cons (exe-path lisp-exe)
+        `("--norc"
+          "--eval (setq clasp-cleavir::*use-ast-interpreter* nil)"
+          ,@(prepend-each "--eval" form-strings)
+          "--eval" "(core:quit)")))
 
 (defmethod make-command-line ((lisp-exe cmucl) form-strings)
   (cons (exe-path lisp-exe)

--- a/agent/lisp-exe.lisp
+++ b/agent/lisp-exe.lisp
@@ -124,15 +124,13 @@ Otherwise he may just ignore the condition."))
              :initarg :compiler
              :initform (error "compiler must be either :bytecode or :lisp-to-c. Can not be NIL"))))
 
-(defclass clasp (single-exe-lisp-exe) ())
-
 (defclass acl (single-exe-lisp-exe) ())
 ;; Lispwork was not verified, as I don't have a license,
 ;; and the free personal edition doesn't have
 ;; a command line executable, only GUI.
 (defclass lispworks (single-exe-lisp-exe) ())
 
-
+(defclass clasp (single-exe-lisp-exe) ())
 ;;;
 ;;; Implementation
 ;;;
@@ -254,13 +252,6 @@ command, the rest strings are the command arguments."))
           ,@(prepend-each "--eval" form-strings)
           "--eval" "(sb-ext:quit)")))
 
-(defmethod make-command-line ((lisp-exe clasp) form-strings)
-  (cons (exe-path lisp-exe)
-        `("--norc"
-          "--eval (setq clasp-cleavir::*use-ast-interpreter* nil)"
-          ,@(prepend-each "--eval" form-strings)
-          "--eval" "(core:quit)")))
-
 (defmethod make-command-line ((lisp-exe cmucl) form-strings)
   (cons (exe-path lisp-exe)
         `("-noinit"
@@ -319,6 +310,13 @@ command, the rest strings are the command arguments."))
           "-eval" "(load-all-patches)"
           ,@(prepend-each "-eval" form-strings)
           "-eval" "(lispworks:quit)")))
+
+(defmethod make-command-line ((lisp-exe clasp) form-strings)
+  (cons (exe-path lisp-exe)
+        `("--norc"
+          #+(or) "--eval (setq clasp-cleavir::*use-ast-interpreter* nil)"
+          ,@(prepend-each "--eval" form-strings)
+          "--eval" "(core:quit)")))
 
 ;;; Timeouts: waiting for the process and killing the process tree on timeout;
 ;;; also detecting the machine hibernation while the process is running.

--- a/agent/proc-common.lisp
+++ b/agent/proc-common.lisp
@@ -10,7 +10,7 @@
 
 ;;; utf-8 external format, if supported by the lisp implementation.
 ;;; copy/pasted from ASDF
-#+(or abcl (and allegro ics) (and (or clisp cmu ecl mkcl) unicode)
+#+(or abcl (and allegro ics) (and (or clasp clisp cmu ecl mkcl) unicode)
       clozure lispworks (and sbcl sb-unicode) scl)
 (eval-when (:load-toplevel :compile-toplevel :execute)
   (pushnew :asdf-unicode *features*))
@@ -71,6 +71,8 @@ hopefully, if done consistently, that won't affect program behavior too much.")
       :from-read-eval-print-loop nil
       :count t
       :all t))
+  #+clasp
+  (core:btcl :stream stream)
   #+clisp
   (system::print-backtrace :out stream :limit count)
   #+(or clozure mcl)


### PR DESCRIPTION
To actually use it in run-agent.lisp
(defparameter *clasp* (make-instance 'lisp-exe:clasp :exe-path "~/lisp/compiler/clasp2/build/clasp"))
and include *clasp*  in test-grid-agent:make-agent

Please note that clasp compiler is very, very slow, so timeouts might be a real pain. Nevertherless it works, e.g. from the log: 
````
<INFO> [20:03:41] tg-agent complete-test-run.lisp (proc-test-loading) - The 1am system load result: (:STATUS :OK)
````
