### PR TITLE
fix obfuscate-base64.lisp

### DIFF
--- a/sptm/obfuscate-base64.lisp
+++ b/sptm/obfuscate-base64.lisp
@@ -111,7 +111,7 @@
   (with-output-to-string (out)
     (with-input-from-string (in str)
       (dostream (in char)
-        (encode-base64-digit char out))))))
+        (encode-base64-digit char out)))))
 
 (defun decode-base64-string (str)
   (with-output-to-string (out)
@@ -148,5 +148,5 @@ original base64 form."
     (decode-base64-string without-spaces)))
 
 (assert (string-equal +base64-digits+
-                      (deobfuscate-base64
-                       (obfuscate-base64 +base64-digits+))))
+                      (deobfuscate-base64-string
+                       (obfuscate-base64-string +base64-digits+))))


### PR DESCRIPTION
After commit f893e8002dcac8b19ab3dfb76c6482b2b0537643 (adding `obfuscate-base64.lisp`) `run-agent` fails, because the new file has some typos in it:
* unbalanced parenthesis
* assert on undefined (misspelled) function

Runs fine after applying this.