### PR TITLE
agent: ecl: do not assume exact printer for ecl compiled function

### DIFF
--- a/agent/agent.lisp
+++ b/agent/agent.lisp
@@ -155,8 +155,9 @@ lib-world identifier of that quicklisp."
               `(load ,(truename (src-file "proc-common.lisp")))
               '(compile (defun cl-user::-unique-name--- ()))
               `(cl-user::set-response ,response-file
-                                      (not (string= "#<compiled-function -UNIQUE-NAME--->"
-                                                    (format nil "~A" (function cl-user::-unique-name---)))))))))
+                                      (not (string= "compiled-function"
+                                                    (subseq (format nil "~A" (function cl-user::-unique-name---))
+                                                             2 19))))))))
       (when compile-failure-p
         (error "ECL implementation ~A can not compile functions. Ensure that C compiler is available in PATH."
                lisp-exe)))))


### PR DESCRIPTION
Recently ECL have added also an address to the compiled function
printed unreadable representation, so instead of:

 #<compiled-function -UNIQUE-NAME--->

We have

 #<compiled-function -UNIQUE-NAME--- 0x55cea7242700>

In order to be more resilent for this kind of mismatches we test in
the agent only for the compiled-function subsequence.