### PR TITLE
Update clasp backtrace

### DIFF
--- a/agent/proc-common.lisp
+++ b/agent/proc-common.lisp
@@ -72,7 +72,7 @@ hopefully, if done consistently, that won't affect program behavior too much.")
       :count t
       :all t))
   #+clasp
-  (core:btcl :stream stream)
+  (clasp-debug:print-backtrace :stream stream)
   #+clisp
   (system::print-backtrace :out stream :limit count)
   #+(or clozure mcl)


### PR DESCRIPTION
* `core:btcl` is no longer present in clasp
* use `clasp-debug:print-backtrace` instead