### PR TITLE
Add missing (:use #:common-lisp) arguments to some defpackage forms

### DIFF
--- a/reporting/status-icon-png.lisp
+++ b/reporting/status-icon-png.lisp
@@ -1,4 +1,5 @@
 (defpackage #:test-grid-reporting/status-icon-png
+  (:use #:common-lisp)
   (:nicknames #:tg-reporting/status-icon-png #:tg-rep/status-icon-png)
   ;; dependency for package inferred system
   (:import-from :vecto)) 

--- a/reporting/status-icon-svg.lisp
+++ b/reporting/status-icon-svg.lisp
@@ -3,6 +3,7 @@
 ;;;; See LICENSE for details.
 
 (defpackage #:test-grid-reporting/status-icon-svg
+  (:use #:common-lisp)
   (:nicknames #:tg-reporting/status-icon-svg #:tg-rep/status-icon-svg))
 
 (in-package :tg-reporting/status-icon-svg)

--- a/reporting/status-icon.lisp
+++ b/reporting/status-icon.lisp
@@ -3,6 +3,7 @@
 ;;;; See LICENSE for details.
 
 (defpackage #:test-grid-reporting/status-icon
+  (:use #:common-lisp)
   (:nicknames #:tg-reporting/status-icon #:tg-rep/status-icon))
 
 (in-package :tg-reporting/status-icon)
@@ -12,7 +13,7 @@
 where earch row is a lisp, and each column is a lib-world.
 The table cell is a symbol designating testing result.
 :FAIL if any failure happend there - a test case, load failure, anything.
-:OK if the testing was successful. 
+:OK if the testing was successful.
 :NONE if there are no results for this lisp / lib-world combination.
 
 Example for three lisps and two lib-worlds:


### PR DESCRIPTION
Needed to work with SBCL.